### PR TITLE
Add super-lint to enable OpenAPI linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,32 @@
+name: Lint
+
+on:  # yamllint disable-line rule:truthy
+  push: null
+  pull_request: null
+
+jobs:
+  build:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: read
+      # To report GitHub Actions status checks
+      statuses: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # super-linter needs the full git history to get the
+          # list of files that changed across commits
+          fetch-depth: 0
+
+      - name: Super-linter
+        uses: super-linter/super-linter@v6.0.0
+        env:
+          DEFAULT_BRANCH: main
+          VALIDATE_OPENAPI: true
+          # To report GitHub Actions status checks
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,8 +1,9 @@
 name: Lint
 
 on:  # yamllint disable-line rule:truthy
-  push: null
-  pull_request: null
+  push:
+    paths-ignore:
+      - 'README.md'
 
 jobs:
   build:
@@ -28,5 +29,4 @@ jobs:
         env:
           DEFAULT_BRANCH: main
           VALIDATE_OPENAPI: true
-          # To report GitHub Actions status checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,9 @@
 name: Lint
 
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
+  pull_request: {}
   push:
+    branches: [main]
     paths-ignore:
       - 'README.md'
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,5 @@
 openapi: 3.1.0
-info1:
+info:
   title: Train Travel API
   description: API for finding and booking train trips across Europe.
   version: 1.0.0

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,5 @@
 openapi: 3.1.0
-
-# Metadata about the API
-info:
+info1:
   title: Train Travel API
   description: API for finding and booking train trips across Europe.
   version: 1.0.0


### PR DESCRIPTION
First time I've tried using super-lint for Spectral linting and it appears to be entirely useless? 

1. At first it said no errors which shows its not picking up the extends in `.spectral.yaml` because there are definitely failures in there.
2. When I made a change to make it invalid OpenAPI it's just dumping out with AGGHH ERRORS instead of reporting them.

<img width="702" alt="Screenshot 2024-02-02 at 11 18 40 AM" src="https://github.com/bump-sh-examples/train-travel-api/assets/67381/4bdbd648-18f7-409c-ab3a-0d65f6e6e897">

What is the point of this then? 