### PR TITLE
polymorphism: add discriminator property name

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -822,6 +822,8 @@ components:
                 - account_type
                 - bank_name
                 - country
+          discriminator:
+            propertyName: object
         status:
           description: The status of the payment, one of `pending`, `succeeded`, or `failed`.
           type: string


### PR DESCRIPTION
This helps to identify which property of the object is changing
depending on the alternative. It adds a visible tag “Discriminator”
next to the property type in the Bump.sh UI.