### PR TITLE
fix: add url to the license to match redocly linting

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14,6 +14,7 @@ info:
   license: 
     name: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
     identifier: CC-BY-NC-SA-4.0
+    url: https://creativecommons.org/licenses/by-nc-sa/4.0/
 
 servers:
   - url: https://api.example.com


### PR DESCRIPTION
Maybe it's just a bit nitpicky, but I think it does make sense especially as a 'this is a nice starter kit to understand openapi design'