### PR TITLE
Require POST body when making a payment

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -475,6 +475,7 @@ paths:
       tags:
         - Payments
       requestBody:
+        required: true
         content:
           application/json:
             schema:


### PR DESCRIPTION
Hi
I noticed that the request body for payments is defined as optional (because [OAS says so](https://spec.openapis.org/oas/latest.html#request-body-object)). This does not look useful when making payments. 

I would also like to ask if you think this assumption is correct: When a request body content is defined, but the request body is not marked as required, both, a request with a body with the described content-type and body schema and a request with and empty body are valid according to the API description.

I was working on [openapi_first](https://github.com/ahx/openapi_first), which is a request/response validator for Ruby, and I am (finally) making use of your project. Thanks for building this.