### PR TITLE
fix: Add missing page query parameter to trips endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -199,6 +199,13 @@ paths:
           schema:
             type: boolean
             default: false
+        - name: page
+          in: query
+          description: The page of results to be returned
+          required: false
+          schema:
+            type: number
+            default: 1
       responses:
         '200':
           description: A list of available train trips


### PR DESCRIPTION
Been building a demo app with wiremock and noticed that the `link` properties include a `page` query parameter so added it to the openapi spec