### PR TITLE
feat: point to microcks mock server

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,7 +26,7 @@ servers:
     description: Production
     x-internal: false
   
-  - url: https://mocks.example.com/rest
+  - url: https://try.microcks.io/rest/Train+Travel+API/1.0.0
     description: Mock Server
     x-internal: false
 


### PR DESCRIPTION
Fixes #25 

Now that https://github.com/bump-sh-examples/train-travel-api/pull/21 is merged the Microcks team have popped the Train Travel API up on their Hub, and their "Try" Demo. 

```
curl -X GET 'https://try.microcks.io/rest/Train+Travel+API/1.0.0/bookings' -H 'Accept: application/json'
```

This means we dont need to host our own demo, and we can publish updates as we go, so lets use their awesome demo to show off how bump and microcks work together.