### PR TITLE
fix: run in postman button

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,16 +5,16 @@ info:
     API for finding and booking train trips across Europe.
 
     ## Run in Postman
-    
+
     Experiment with this API in Postman, using our Postman Collection.
 
-    [<img src="https://run.pstmn.io/button.svg" alt="Run In Postman" style="width: 128px; height: 32px;">](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
+    [![Run In Postman](https://run.pstmn.io/button.svg =128pxx32px)](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
   version: 1.0.0
   contact:
     name: Train Support
     url: https://example.com/support
     email: support@example.com
-  license: 
+  license:
     name: Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
     identifier: CC-BY-NC-SA-4.0
   x-feedbackLink:
@@ -25,7 +25,7 @@ servers:
   - url: https://api.example.com
     description: Production
     x-internal: false
-  
+
   - url: https://try.microcks.io/rest/Train+Travel+API/1.0.0
     description: Mock Server
     x-internal: false


### PR DESCRIPTION
<img> tags are now forbidden in API documents on Bump.sh we need to
use markdown syntax to be able to display the button image.