### PR TITLE
mocks: add /stations?search= samples for “paris” and “berlin” values

### DIFF
--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -11,9 +11,8 @@ info:
     Experiment with this API in Postman, using our Postman Collection.
 
 
-    [<img src="https://run.pstmn.io/button.svg" alt="Run In Postman"
-    style="width: 128px; height:
-    32px;">](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
+    [![Run In Postman](https://run.pstmn.io/button.svg
+    =128pxx32px)](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
   version: 1.0.0
   contact:
     name: Train Support
@@ -91,6 +90,13 @@ paths:
             examples:
               - Milano Centrale
               - Paris
+          examples:
+            berlin_station:
+              value: Berlin
+            milano_station:
+              value: Milano
+            paris_station:
+              value: Paris
         - name: country
           in: query
           description: Filter stations by country code
@@ -127,12 +133,14 @@ paths:
                   summary: A list of train stations
                   value:
                     data:
-                      - id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                      - &ref_0
+                        id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
                         name: Berlin Hauptbahnhof
                         address: 'Invalidenstraße 10557 Berlin, Germany'
                         country_code: DE
                         timezone: Europe/Berlin
-                      - id: b2e783e1-c824-4d63-b37a-d8d698862f1d
+                      - &ref_1
+                        id: b2e783e1-c824-4d63-b37a-d8d698862f1d
                         name: Paris Gare du Nord
                         address: '18 Rue de Dunkerque 75010 Paris, France'
                         country_code: FR
@@ -141,6 +149,14 @@ paths:
                       self: 'https://api.example.com/stations&page=2'
                       next: 'https://api.example.com/stations?page=3'
                       prev: 'https://api.example.com/stations?page=1'
+                berlin_station:
+                  value:
+                    data:
+                      - *ref_0
+                paris_station:
+                  value:
+                    data:
+                      - *ref_1
             application/xml:
               schema:
                 allOf:
@@ -1310,4 +1326,3 @@ components:
             title: Unauthorized
             status: 401
             detail: You do not have the necessary permissions.
-

--- a/.microcks/overlays.yaml
+++ b/.microcks/overlays.yaml
@@ -25,12 +25,14 @@ actions:
           summary: A list of train stations
           value:
             data:
-              - id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+              - &berlin_station
+                id: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
                 name: Berlin Hauptbahnhof
                 address: Invalidenstraße 10557 Berlin, Germany
                 country_code: DE
                 timezone: Europe/Berlin
-              - id: b2e783e1-c824-4d63-b37a-d8d698862f1d
+              - &paris_station
+                id: b2e783e1-c824-4d63-b37a-d8d698862f1d
                 name: Paris Gare du Nord
                 address: 18 Rue de Dunkerque 75010 Paris, France
                 country_code: FR
@@ -39,6 +41,29 @@ actions:
               self: https://api.example.com/stations&page=2
               next: https://api.example.com/stations?page=3
               prev: https://api.example.com/stations?page=1
+        berlin_station:
+          value:
+            data:
+              - *berlin_station
+        paris_station:
+          value:
+            data:
+              - *paris_station
+
+  - target: $.paths["/stations"].get.parameters[?(@.name=="search")].example
+    description: Remove the example from get /stations - search parameter.
+    remove: true
+
+  - target: $.paths["/stations"].get.parameters[?(@.name=="search")]
+    description: Add Microcks examples for get /stations - search parameter
+    update:
+      examples:
+        berlin_station:
+          value: "Berlin"
+        milano_station:
+          value: "Milano"
+        paris_station:
+          value: "Paris"
 
   - target: $.paths["/trips"].get.parameters[?(@.name=="origin")].example
     description: Remove the example from get /trips - origin parameter.


### PR DESCRIPTION
This change adds the examples to be able to use the /stations
operation with the `?search=` query param with two example values:
Paris or Berlin