### PR TITLE
servers: re-order to put mocking server first

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,12 +22,12 @@ info:
     url: https://github.com/bump-sh-examples/train-travel-api/issues/new
 
 servers:
-  - url: https://api.example.com
-    description: Production
-    x-internal: false
-
   - url: https://try.microcks.io/rest/Train+Travel+API/1.0.0
     description: Mock Server
+    x-internal: false
+
+  - url: https://api.example.com
+    description: Production
     x-internal: false
 
 security:


### PR DESCRIPTION
This is a tiny update to make the mocking server available as first
server in the list of available servers.

It helps for “first” visit of an API explorer to make the mocking
server the first selected server.