### PR TITLE
feat/add trips station links

### DIFF
--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -13,7 +13,7 @@ info:
 
     [![Run In Postman](https://run.pstmn.io/button.svg
     =128pxx32px)](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
-  version: 1.0.0
+  version: 1.2.0
   contact:
     name: Train Support
     url: 'https://example.com/support'
@@ -270,7 +270,10 @@ paths:
                       data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Trip'
+                          allOf:
+                            - $ref: '#/components/schemas/Trip'
+                            - $ref: '#/components/schemas/Links-Origin'
+                            - $ref: '#/components/schemas/Links-Destination'
                   - properties:
                       links:
                         allOf:
@@ -820,6 +823,20 @@ components:
             - Europe/Paris
     Links-Self:
       type: object
+      properties:
+        self:
+          type: string
+          format: uri
+    Links-Destination:
+      type: object
+      description: The link to the destination station resource.
+      properties:
+        self:
+          type: string
+          format: uri
+    Links-Origin:
+      type: object
+      description: The link to the origin station resource.
       properties:
         self:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,7 +9,7 @@ info:
     Experiment with this API in Postman, using our Postman Collection.
 
     [![Run In Postman](https://run.pstmn.io/button.svg =128pxx32px)](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
-  version: 1.1.0
+  version: 1.2.0
   contact:
     name: Train Support
     url: https://example.com/support

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -244,7 +244,10 @@ paths:
                       data:
                         type: array
                         items:
-                          $ref: '#/components/schemas/Trip'
+                          allOf:
+                            - $ref: '#/components/schemas/Trip'
+                            - $ref: '#/components/schemas/Links-Origin'
+                            - $ref: '#/components/schemas/Links-Destination'
                   - properties:
                       links:
                         allOf:
@@ -261,6 +264,10 @@ paths:
                     operator: Deutsche Bahn
                     bicycles_allowed: true
                     dogs_allowed: true
+                    links:
+                      self: https://api.example.com/trips/ea399ba1-6d95-433f-92d1-83f67b775594
+                      origin: https://api.example.com/stations/efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+                      destination: https://api.example.com/stations/b2e783e1-c824-4d63-b37a-d8d698862f1d
                   - id: 4d67459c-af07-40bb-bb12-178dbb88e09f
                     origin: b2e783e1-c824-4d63-b37a-d8d698862f1d
                     destination: efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
@@ -270,6 +277,10 @@ paths:
                     operator: SNCF
                     bicycles_allowed: true
                     dogs_allowed: true
+                    links:
+                      self: https://api.example.com/trips/4d67459c-af07-40bb-bb12-178dbb88e09f
+                      origin: https://api.example.com/stations/b2e783e1-c824-4d63-b37a-d8d698862f1d
+                      destination: https://api.example.com/stations/efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
                 links:
                   self: https://api.example.com/trips?origin=efdbb9d1-02c2-4bc3-afb7-6788d8782b1e&destination=b2e783e1-c824-4d63-b37a-d8d698862f1d&date=2024-02-01
                   next: https://api.example.com/trips?origin=efdbb9d1-02c2-4bc3-afb7-6788d8782b1e&destination=b2e783e1-c824-4d63-b37a-d8d698862f1d&date=2024-02-01&page=2
@@ -747,6 +758,20 @@ components:
             - Europe/Paris
     Links-Self:
       type: object
+      properties:
+        self:
+          type: string
+          format: uri
+    Links-Destination:
+      type: object
+      description: The link to the destination station resource.
+      properties:
+        self:
+          type: string
+          format: uri
+    Links-Origin:
+      type: object
+      description: The link to the origin station resource.
       properties:
         self:
           type: string


### PR DESCRIPTION
_Includes #41 which should be merged first._

This is an experiment with adding links to resources in a collection, which bump seems to reorder despite a full example providing the links at the bottom of the resource. 

<img width="557" alt="Screenshot 2024-12-10 at 2 52 26 PM" src="https://github.com/user-attachments/assets/e365884b-18b8-4cab-a754-addd6c662ccb">
