### PR TITLE
fix: use string type for CVC

### DIFF
--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -605,7 +605,7 @@ paths:
                     object: card
                     name: J. Doe
                     number: '4242424242424242'
-                    cvc: 123
+                    cvc: '123'
                     exp_month: 12
                     exp_year: 2025
                     address_line1: 123 Fake Street
@@ -653,7 +653,7 @@ paths:
                       object: card
                       name: J. Doe
                       number: '************4242'
-                      cvc: 123
+                      cvc: '123'
                       exp_month: 12
                       exp_year: 2025
                       address_country: gb
@@ -1016,7 +1016,7 @@ components:
                   examples:
                     - '4242424242424242'
                 cvc:
-                  type: integer
+                  type: string
                   description: >-
                     Card security code, 3 or 4 digits usually found on the back
                     of the card.

--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -1023,7 +1023,7 @@ components:
                   minLength: 3
                   maxLength: 4
                   writeOnly: true
-                  example: 123
+                  example: '123'
                 exp_month:
                   type: integer
                   format: int64

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -550,7 +550,7 @@ paths:
                     object: card
                     name: J. Doe
                     number: '4242424242424242'
-                    cvc: 123
+                    cvc: '123'
                     exp_month: 12
                     exp_year: 2025
                     address_line1: 123 Fake Street
@@ -598,7 +598,7 @@ paths:
                       object: card
                       name: J. Doe
                       number: '************4242'
-                      cvc: 123
+                      cvc: '123'
                       exp_month: 12
                       exp_year: 2025
                       address_country: gb
@@ -935,13 +935,13 @@ components:
                   examples:
                     - '4242424242424242'
                 cvc:
-                  type: integer
+                  type: string
                   description: Card security code, 3 or 4 digits usually found on the back of the card.
                   minLength: 3
                   maxLength: 4
                   writeOnly: true
 
-                  example: 123
+                  example: '123'
                 exp_month:
                   type: integer
                   format: int64


### PR DESCRIPTION
`minLength` and `maxLength` constraints are only applicable to string type,
need help with regenerating NodeJS `server`