### PR TITLE
fix: CVC type should be string not integer

### DIFF
--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -605,7 +605,7 @@ paths:
                     object: card
                     name: J. Doe
                     number: '4242424242424242'
-                    cvc: 123
+                    cvc: '123'
                     exp_month: 12
                     exp_year: 2025
                     address_line1: 123 Fake Street
@@ -653,7 +653,7 @@ paths:
                       object: card
                       name: J. Doe
                       number: '************4242'
-                      cvc: 123
+                      cvc: '123'
                       exp_month: 12
                       exp_year: 2025
                       address_country: gb
@@ -1016,7 +1016,7 @@ components:
                   examples:
                     - '4242424242424242'
                 cvc:
-                  type: integer
+                  type: string
                   description: >-
                     Card security code, 3 or 4 digits usually found on the back
                     of the card.

--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -1023,7 +1023,7 @@ components:
                   minLength: 3
                   maxLength: 4
                   writeOnly: true
-                  example: 123
+                  example: '123'
                 exp_month:
                   type: integer
                   format: int64

--- a/.microcks/openapi.yaml
+++ b/.microcks/openapi.yaml
@@ -25,12 +25,22 @@ info:
     label: Submit Feedback
     url: 'https://github.com/bump-sh-examples/train-travel-api/issues/new'
 servers:
-  - url: 'https://api.example.com'
-    description: Production
-    x-internal: false
   - url: 'https://try.microcks.io/rest/Train+Travel+API/1.0.0'
     description: Mock Server
     x-internal: false
+  - url: 'https://api.example.com'
+    description: Production
+    x-internal: false
+x-speakeasy-retries:
+  strategy: backoff
+  backoff:
+    initialInterval: 500
+    maxInterval: 60000
+    maxElapsedTime: 3600000
+    exponent: 1.5
+  statusCodes:
+    - 5XX
+  retryConnectionErrors: true
 security:
   - OAuth2:
       - read
@@ -605,7 +615,7 @@ paths:
                     object: card
                     name: J. Doe
                     number: '4242424242424242'
-                    cvc: '123'
+                    cvc: 123
                     exp_month: 12
                     exp_year: 2025
                     address_line1: 123 Fake Street
@@ -701,6 +711,7 @@ webhooks:
       tags:
         - Bookings
       requestBody:
+        required: true
         content:
           application/json:
             schema:
@@ -872,14 +883,14 @@ components:
           type: string
           description: The starting station of the trip
           examples:
-            - Berlin Hauptbahnhof
-            - Paris Gare du Nord
+            - efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
+            - b2e783e1-c824-4d63-b37a-d8d698862f1d
         destination:
           type: string
           description: The destination station of the trip
           examples:
-            - Paris Gare du Nord
-            - Berlin Hauptbahnhof
+            - b2e783e1-c824-4d63-b37a-d8d698862f1d
+            - efdbb9d1-02c2-4bc3-afb7-6788d8782b1e
         departure_time:
           type: string
           format: date-time
@@ -1326,3 +1337,4 @@ components:
             title: Unauthorized
             status: 401
             detail: You do not have the necessary permissions.
+

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -550,7 +550,7 @@ paths:
                     object: card
                     name: J. Doe
                     number: '4242424242424242'
-                    cvc: 123
+                    cvc: '123'
                     exp_month: 12
                     exp_year: 2025
                     address_line1: 123 Fake Street
@@ -598,7 +598,7 @@ paths:
                       object: card
                       name: J. Doe
                       number: '************4242'
-                      cvc: 123
+                      cvc: '123'
                       exp_month: 12
                       exp_year: 2025
                       address_country: gb
@@ -935,13 +935,13 @@ components:
                   examples:
                     - '4242424242424242'
                 cvc:
-                  type: integer
+                  type: string
                   description: Card security code, 3 or 4 digits usually found on the back of the card.
                   minLength: 3
                   maxLength: 4
                   writeOnly: true
 
-                  example: 123
+                  example: '123'
                 exp_month:
                   type: integer
                   format: int64

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -9,7 +9,7 @@ info:
     Experiment with this API in Postman, using our Postman Collection.
 
     [![Run In Postman](https://run.pstmn.io/button.svg =128pxx32px)](https://app.getpostman.com/run-collection/9265903-7a75a0d0-b108-4436-ba54-c6139698dc08?action=collection%2Ffork&source=rip_markdown&collection-url=entityId%3D9265903-7a75a0d0-b108-4436-ba54-c6139698dc08%26entityType%3Dcollection%26workspaceId%3Df507f69d-9564-419c-89a2-cb8e4c8c7b8f)
-  version: 1.0.0
+  version: 1.1.0
   contact:
     name: Train Support
     url: https://example.com/support


### PR DESCRIPTION
- **fix: use string type for CVC**
- **fix example**
- **regenerate microcks**
- **start bumping openapi ever**
